### PR TITLE
progress bar on timeline now fills relative to length of playSequence

### DIFF
--- a/Assets/Scenes/Prototype.unity
+++ b/Assets/Scenes/Prototype.unity
@@ -312,7 +312,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 591307459}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.11, y: -4.51, z: 0}
+  m_LocalPosition: {x: -2.86, y: -4.51, z: 0}
   m_LocalScale: {x: 1.60787, y: 0.39899993, z: 0.72959995}
   m_Children: []
   m_Father: {fileID: 2047535046}
@@ -524,6 +524,36 @@ Transform:
   - {fileID: 1219229587}
   m_Father: {fileID: 0}
   m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &784934629
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 784934630}
+  m_Layer: 0
+  m_Name: Actions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &784934630
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 784934629}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1871161701}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &792269249
 GameObject:
@@ -813,7 +843,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1256627175}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.033333298, y: -3.51, z: 0}
+  m_LocalPosition: {x: -1.51, y: -3.51, z: 0}
   m_LocalScale: {x: 0.7954831, y: 0.39899993, z: 0.72959995}
   m_Children: []
   m_Father: {fileID: 1736742228}
@@ -1163,6 +1193,85 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1782965256
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1782965257}
+  - component: {fileID: 1782965258}
+  m_Layer: 0
+  m_Name: ProgressBar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1782965257
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1782965256}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -8.39, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1871161701}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1782965258
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1782965256}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -84788881
+  m_SortingLayer: 4
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 7939523228288b348b48972ad13fa8d5, type: 3}
+  m_Color: {r: 0.39121464, g: 0.9528302, b: 0.09438412, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4, y: 1.5}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &1871161699
 GameObject:
   m_ObjectHideFlags: 0
@@ -1214,10 +1323,10 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -84788881
-  m_SortingLayer: 4
+  m_SortingLayerID: 1821969777
+  m_SortingLayer: 3
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: ec1b47fef45ddeb468490b6a61a5e0f6, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ed32d864c5f6f42459af7cc0edfecf80, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -1236,9 +1345,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1871161699}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.77, y: 4.23, z: 0}
+  m_LocalPosition: {x: -0.09, y: 4.21, z: 0}
   m_LocalScale: {x: 0.9, y: 0.9, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1782965257}
+  - {fileID: 784934630}
   m_Father: {fileID: 0}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1348,6 +1459,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2047535046}
   - component: {fileID: 2047535045}
+  - component: {fileID: 2047535047}
   m_Layer: 0
   m_Name: Enemy
   m_TagString: Untagged
@@ -1418,6 +1530,32 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &2047535047
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2047535044}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 7.01, y: 8.97}
+    newSize: {x: 7.01, y: 8.97}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 7.01, y: 8.97}
+  m_EdgeRadius: 0
 --- !u!1 &2088215219
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ActionRenderer.cs
+++ b/Assets/Scripts/ActionRenderer.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ActionRenderer : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start() {
+        
+    }
+
+    // Update is called once per frame
+    void Update() {
+        
+    }
+}

--- a/Assets/Scripts/ActionRenderer.cs.meta
+++ b/Assets/Scripts/ActionRenderer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: edf71bdfa3fcc10419cdc48a5f246bcc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Board.cs
+++ b/Assets/Scripts/Board.cs
@@ -3,11 +3,9 @@ using System.Collections.Generic;
 using UnityEngine;
 using System.IO;
 
-public enum Phase {Mulligan, Play, Resolution};
-public class Board : MonoBehaviour
-{
+public enum Phase { Mulligan, Play, Resolution };
+public class Board : MonoBehaviour {
     private string deckFileName = "deck.json";
-
     public Phase curPhase;
     
     // "entity" fields
@@ -15,7 +13,7 @@ public class Board : MonoBehaviour
     public GameObject player;
     public GameObject[] enemies;
 
-    // card manipulating fields
+    // CARD MANIPULATING FIELDS //
     public GameObject cardPrefab;
     private List<GameObject> pool = new List<GameObject>();
     private Dictionary<string, Sprite> cardArtDict = new Dictionary<string, Sprite>();
@@ -33,7 +31,7 @@ public class Board : MonoBehaviour
     public List<GameObject> lockedHand = new List<GameObject>(); // also subset of `hand`, union with `toMul` is equal to `hand`
 
     // PLAY PHASE VARIABLES //
-    public Queue<Action> playSequence = new Queue<Action>();
+    public PlaySequence<Action> playSequence = new PlaySequence<Action>();
     
 
     [System.Serializable]
@@ -52,13 +50,48 @@ public class Board : MonoBehaviour
         public string artPath;
     }
 
+    // Action describes an action that can be enqueued during the play phase.
+    // This includes the card to be played for the action, its target(s), and
+    // the time cost of the action.
     public class Action {
-        public Action(Card card, GameObject target) {
-            this.card = card;
-            this.target = target;
-        }
         public Card card;
         public GameObject target;
+        public int cost;
+
+        public Action(Card card, GameObject target, int cost) {
+            this.card = card;
+            this.target = target;
+            this.cost = cost;
+        }
+        
+    }
+
+    // Extension of List, used to model the sequence of actions created
+    // during the play phase, and executed during the resolution phase.
+    public class PlaySequence<T> : List<T> {
+        public List<Action> sequence;
+        public int totalTime;
+
+        public PlaySequence() {
+            sequence = new List<Action>();
+            totalTime = 0;
+        }
+
+        public new void Add(T item) {
+            base.Add(item);
+            if(item.GetType() == typeof(Board.Action)) {
+                Board.Action action = item as Action;
+                totalTime += action.cost;
+            }
+        }
+
+        public new void Remove(T item) {
+            base.Remove(item);
+            if(item.GetType() == typeof(Board.Action)) {
+                Board.Action action = item as Action;
+                totalTime -= action.cost;
+            }
+        }
     }
     
     public void Mulligan(Card card) {
@@ -179,7 +212,6 @@ public class Board : MonoBehaviour
     void Update(){
         deckCount = deck.Count; // exposes variable for debug
         switch(curPhase){
-            // TODO: Change Card.cs to add the card to toMul on click, and then execute a Mulligan routine and lock cards in hand, then begin next turn
             case Phase.Mulligan:
                 if(mulLimit == 0) {
                     Debug.Log("now in play phase");

--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -219,8 +219,7 @@ public class Card : MonoBehaviour
             foreach(Collider2D collider in colliders) {
                 if(collider.GetComponent<SpriteRenderer>() == null) continue;
                 if(collider.GetComponent<SpriteRenderer>().sortingLayerName == "Targets") {
-                    Debug.Log("hit");
-                    board.playSequence.Enqueue(new Board.Action(this, collider.gameObject));
+                    board.playSequence.Add(new Board.Action(this, collider.gameObject, cost));
                     curState = CardState.InQueue;
                 }
             }

--- a/Assets/Scripts/ProgressBar.cs
+++ b/Assets/Scripts/ProgressBar.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using DG.Tweening;
+
+public class ProgressBar : MonoBehaviour
+{
+    private Board board;
+
+    void Start() {
+        SpriteRenderer sr = GetComponent<SpriteRenderer>();
+        sr.color = new Color(sr.color.r, sr.color.g, sr.color.b, .5f);
+        board = Board.me;
+    }
+
+    void Update() {
+        if(board.curPhase == Phase.Play || board.curPhase == Phase.Resolution) {
+            transform.DOScaleX(board.playSequence.totalTime, .2f * board.playSequence.totalTime);
+        }
+    }
+}

--- a/Assets/Scripts/ProgressBar.cs.meta
+++ b/Assets/Scripts/ProgressBar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6e4525768663604a8b4ea38f3ecde17
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/UI/ph_UI_bossTarget_1.png.meta
+++ b/Assets/Sprites/UI/ph_UI_bossTarget_1.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7939523228288b348b48972ad13fa8d5
+guid: b7f880202d7825d4fbd00d879b85c382
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}
@@ -43,9 +43,9 @@ TextureImporter:
   spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
-  alignment: 9
-  spritePivot: {x: 0.05, y: 0.5}
-  spritePixelsToUnits: 315
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -69,57 +69,13 @@ TextureImporter:
     allowsAlphaSplitting: 0
     overridden: 0
     androidETC2FallbackOverride: 0
-  - serializedVersion: 2
-    buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 1
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - serializedVersion: 2
-    buildTarget: iPhone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 1
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - serializedVersion: 2
-    buildTarget: Android
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 1
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - serializedVersion: 2
-    buildTarget: WebGL
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 1
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 2637a677e33000c4eada1c70c7b23f80
+    spriteID: ba065235fecc736418d2fb5391e8d96e
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/UI/ph_UI_timeline_2.png.meta
+++ b/Assets/Sprites/UI/ph_UI_timeline_2.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7939523228288b348b48972ad13fa8d5
+guid: ed32d864c5f6f42459af7cc0edfecf80
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}
@@ -43,9 +43,9 @@ TextureImporter:
   spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
-  alignment: 9
-  spritePivot: {x: 0.05, y: 0.5}
-  spritePixelsToUnits: 315
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -69,57 +69,13 @@ TextureImporter:
     allowsAlphaSplitting: 0
     overridden: 0
     androidETC2FallbackOverride: 0
-  - serializedVersion: 2
-    buildTarget: Standalone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 1
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - serializedVersion: 2
-    buildTarget: iPhone
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 1
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - serializedVersion: 2
-    buildTarget: Android
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 1
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
-  - serializedVersion: 2
-    buildTarget: WebGL
-    maxTextureSize: 2048
-    resizeAlgorithm: 0
-    textureFormat: -1
-    textureCompression: 1
-    compressionQuality: 50
-    crunchedCompression: 0
-    allowsAlphaSplitting: 0
-    overridden: 0
-    androidETC2FallbackOverride: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 2637a677e33000c4eada1c70c7b23f80
+    spriteID: c972cebee0cead14a9055f2561712c05
     vertices: []
     indices: 
     edges: []


### PR DESCRIPTION
next up will be figuring out a way to render the actions in the `playSequence` as rectangles of appropriate length below the timeline, with the name of the card and other pertinent information.