### PR TITLE
Play-Resolution Transition and Resolution Scaffolding

### DIFF
--- a/Assets/Scenes/Prototype.unity
+++ b/Assets/Scenes/Prototype.unity
@@ -1438,7 +1438,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 1973838493
   m_SortingLayer: 5
-  m_SortingOrder: 0
+  m_SortingOrder: 5
   m_Sprite: {fileID: 21300000, guid: a72a9d37ff541054689b492297694595, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -1491,6 +1491,7 @@ GameObject:
   - component: {fileID: 2047535046}
   - component: {fileID: 2047535045}
   - component: {fileID: 2047535047}
+  - component: {fileID: 2047535048}
   m_Layer: 0
   m_Name: Enemy
   m_TagString: Untagged
@@ -1587,6 +1588,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 7.01, y: 8.97}
   m_EdgeRadius: 0
+--- !u!114 &2047535048
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2047535044}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96886c92a54dbdf4dbba5f4186960963, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2088215219
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Action.cs
+++ b/Assets/Scripts/Action.cs
@@ -2,15 +2,17 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Action : MonoBehaviour
+public class Action
 {
-    public Card card;
     public int completeTime;
     public GameObject target;
     public GameObject instance;
 
-    public Action(Card card, GameObject target) {
-        this.card = card;
+    public Action() {
+        this.target = GameObject.Find("Player");
+    }
+
+    public Action(GameObject target) {
         this.target = target;
     }
 

--- a/Assets/Scripts/ActionRenderer.cs
+++ b/Assets/Scripts/ActionRenderer.cs
@@ -16,17 +16,20 @@ public class ActionRenderer : MonoBehaviour
 
     // Update is called once per frame
     void Update() {
-        foreach(Action action in board.playSequence) {
-            if(!action.instance) {
-                action.instance = Instantiate(actionPrefab, 
-                    action.target.transform.position, Quaternion.identity, this.transform);
-                action.instance.GetComponent<SpriteRenderer>().size = new Vector2(action.card.cost * OFFSET, .45f);
-                action.instance.GetComponentInChildren<TextMeshPro>().text = $"{action.card.cost}: {action.card.cardName}";
-                action.instance.GetComponentInChildren<RectTransform>().sizeDelta = new Vector2(action.card.cost * OFFSET, .45f);
-                action.instance.transform.DOLocalMove(new Vector3((action.completeTime - action.card.cost) * 1.15f, 0, 0), .2f);
+        foreach(Action entry in board.playSequence) {
+            if(entry.GetType() == typeof(PlayerAction)) {
+                PlayerAction action = entry as PlayerAction;
+                if(!action.instance) {
+                    action.instance = Instantiate(actionPrefab, action.target.transform.position, Quaternion.identity, this.transform);
+                    action.instance.GetComponent<SpriteRenderer>().size = new Vector2(action.card.cost * OFFSET, .45f);
+                    action.instance.GetComponentInChildren<TextMeshPro>().text = $"{action.card.cost}: {action.card.cardName}";
+                    action.instance.GetComponentInChildren<RectTransform>().sizeDelta = new Vector2(action.card.cost * OFFSET, .45f);
+                    action.instance.transform.DOLocalMove(new Vector3((action.completeTime - action.card.cost) * 1.15f, 0, 0), .2f);
 
-                // TODO: Add dequeueing functionality
+                    // TODO: Add dequeueing functionality
+                }
             }
+            
         }
     }
 }

--- a/Assets/Scripts/Board.cs
+++ b/Assets/Scripts/Board.cs
@@ -73,19 +73,24 @@ public class Board : MonoBehaviour {
             sequence = new List<Action>();
             totalTime = 0;
         }
-
+        public int IndexOfCompleteTime(int targetTime) {
+            foreach(Action action in this.sequence){
+                if(action.completeTime == targetTime) return sequence.IndexOf(action);
+            }
+            return -1;
+        }
         public new void Add(T item) {
             base.Add(item);
-            if(item.GetType() == typeof(Action)) {
-                Action action = item as Action;
+            if(item.GetType() == typeof(PlayerAction)) {
+                PlayerAction action = item as PlayerAction;
                 totalTime += action.card.cost;
             }
         }
 
         public new void Remove(T item) {
             base.Remove(item);
-            if(item.GetType() == typeof(Action)) {
-                Action action = item as Action;
+            if(item.GetType() == typeof(PlayerAction)) {
+                PlayerAction action = item as PlayerAction;
                 totalTime -= action.card.cost;
             }
         }

--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -237,7 +237,7 @@ public class Card : MonoBehaviour
             foreach(Collider2D collider in colliders) {
                 if(collider.GetComponent<SpriteRenderer>() == null) continue;
                 if(collider.GetComponent<SpriteRenderer>().sortingLayerName == "Targets") {
-                    Action toInsert = new Action(this, collider.gameObject);
+                    PlayerAction toInsert = new PlayerAction(this, collider.gameObject);
                     toInsert.completeTime = board.playSequence.totalTime + toInsert.card.cost; // TODO: integrate this calculation as a method on Action?
                     board.playSequence.Add(toInsert);
                     curState = CardState.InQueue;

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Enemy : MonoBehaviour
+{
+    private Board board;
+
+    private int health;
+    private List<EnemyAction> prevActions;
+    private List<EnemyAction> curActions;
+
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        board = Board.me;
+    }
+
+    // Update is called once per frame
+    void Update() {
+        switch(board.curPhase) {
+            case Phase.Mulligan:
+                // not sure if these two lines work - check later if something is wrong
+                prevActions = curActions;
+                curActions.Clear(); 
+                // roll for action type and display non-numerical intent
+                if(curActions.Count == 0) {
+                    for(int i = 0; i < Random.Range(0, 2); i++) { 
+                        ActionType actionType = (ActionType)Random.Range(0, 2); // change to max 3 when we added statuses
+                        // temporary cheeky one-liner - if it's an attack, target player, if not, target self
+                        GameObject target = actionType == ActionType.Attack ? GameObject.Find("Player") : this.gameObject;
+                        curActions.Add(new EnemyAction(actionType, target));
+                        Debug.Log($"enemy will take action of type: {curActions[i].actionType}");
+                    }
+
+                }
+                break;
+            case Phase.Play:
+                foreach(EnemyAction actionToAdd in curActions) {
+                    if(!board.playSequence.Contains(actionToAdd)) {
+                        int idx = board.playSequence.IndexOfCompleteTime(actionToAdd.completeTime);
+                        board.playSequence.Insert(idx + 1, actionToAdd); // insert AFTER given index to give player priority in resolution
+                    }
+                }
+                break;
+        }
+    }
+}

--- a/Assets/Scripts/Enemy.cs.meta
+++ b/Assets/Scripts/Enemy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96886c92a54dbdf4dbba5f4186960963
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/EnemyAction.cs
+++ b/Assets/Scripts/EnemyAction.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum ActionType { Attack, Defense, Status };
+
+public class EnemyAction: Action
+{
+    public ActionType actionType;
+    public int actionVal;
+
+    public EnemyAction(ActionType actionType, GameObject target) : base(target) {
+        this.actionType = actionType;
+        if(this.actionType == ActionType.Attack || this.actionType == ActionType.Defense) {
+            this.actionVal = Random.Range(5, 16);
+        }
+        this.completeTime = Random.Range(2, 11);
+    }
+
+    public void resolveAction() {
+        // do things to resolve action
+    }
+
+}

--- a/Assets/Scripts/EnemyAction.cs.meta
+++ b/Assets/Scripts/EnemyAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5564e460b98a9424788db7b853bf1a06
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Player : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/Player.cs.meta
+++ b/Assets/Scripts/Player.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8eea16ac51a7c5144bb2e2541cc46a41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PlayerAction.cs
+++ b/Assets/Scripts/PlayerAction.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerAction: Action 
+{
+    public Card card;
+
+    public PlayerAction(Card card, GameObject target) : base(target) {
+        this.card = card;
+    }
+
+    public void resolveAction() {
+        // do things to resolve action based on data given in card field
+    }
+
+}

--- a/Assets/Scripts/PlayerAction.cs.meta
+++ b/Assets/Scripts/PlayerAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 333ceb7b3eba97643aeeca1d995e05c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Lots of new scripts - wrote a basic "dummy" enemy AI which sends its actions to the `playSequence` queue, and also diversified the generic `Action` class into superclasses `PlayerAction` and `EnemyAction` which resolve differently - the former using data from a `Card` object, and the latter using various data fields internal to the class. With the new player/enemy scripts, the MVC model is getting a little blurrier, but I feel this is kind of unavoidable as the game system becomes more complicated.